### PR TITLE
Enable IPv6

### DIFF
--- a/setup/tools/util.sh
+++ b/setup/tools/util.sh
@@ -5,3 +5,7 @@
 apt-fast install --no-install-recommends -y nano tmux watch micro htop ftp inetutils-ping nfs-common openvpn
 
 # * GIT INSTALLED UTILS *
+
+# OpenVPN - enable IPv6 to allow connection with HTB
+sysctl net.ipv6.conf.all.disable_ipv6=0
+


### PR DESCRIPTION
I use your Pwnbox to play with HTB. IPv6 is a requirement for the connection to the HTB labs. To enable this, I propose to add to the `setup/tools.util.sh`:
```bash
sysctl net.ipv6.conf.all.disable_ipv6=0
```